### PR TITLE
[Draft] Major cleanup, simplifies a lot of logic

### DIFF
--- a/src/services/fraud-prover.service.ts
+++ b/src/services/fraud-prover.service.ts
@@ -11,16 +11,12 @@ import {
   StateTransitionPhase,
   FraudProofData,
   OvmTransaction,
-  StateRootBatchProof,
-  TransactionBatchProof,
   AccountStateProof,
   StorageStateProof,
 } from '../types'
 import {
   sleep,
-  ZERO_ADDRESS,
   loadContract,
-  loadContractFromManager,
   L1ProviderWrapper,
   L2ProviderWrapper,
   toHexString,

--- a/src/services/fraud-prover.service.ts
+++ b/src/services/fraud-prover.service.ts
@@ -31,6 +31,7 @@ import {
   waitForNetwork,
   loadOptimismContracts,
   OptimismContracts,
+  asciiToHex,
 } from '../utils'
 
 interface FraudProverOptions {
@@ -486,7 +487,7 @@ export class FraudProverService extends BaseService<FraudProverOptions> {
           err
             .toString()
             .includes(
-              '46756e6374696f6e206d7573742062652063616c6c656420647572696e672074686520636f72726563742070686173652e'
+              asciiToHex('Function must be called during the correct phase.')
             )
         ) {
           this.logger.interesting(

--- a/src/types/ovm.types.ts
+++ b/src/types/ovm.types.ts
@@ -1,3 +1,4 @@
+/* Imports: External */
 import { BigNumber } from 'ethers'
 import { BaseTrie } from 'merkle-patricia-tree'
 

--- a/src/utils/eth-utils.ts
+++ b/src/utils/eth-utils.ts
@@ -1,8 +1,10 @@
 import * as rlp from 'rlp'
-import { BigNumber } from 'ethers'
+import { BigNumber, Contract, logger } from 'ethers'
 import { Account, BN } from 'ethereumjs-util'
 
+import { sleep } from './common'
 import { toHexString, fromHexString } from './hex-utils'
+import { JsonRpcProvider } from '@ethersproject/providers'
 
 export const encodeAccountState = (state: Partial<any>): Buffer => {
   return new Account(
@@ -20,5 +22,73 @@ export const decodeAccountState = (state: Buffer): any => {
     balance: BigNumber.from(account.nonce.toNumber()),
     storageRoot: toHexString(account.stateRoot),
     codeHash: toHexString(account.codeHash),
+  }
+}
+
+export const waitForNetwork = async (
+  provider: JsonRpcProvider,
+  name: string,
+  logger: any
+): Promise<void> => {
+  logger.info(`Trying to connect to network: ${name}...`)
+
+  for (let i = 0; i < 10; i++) {
+    try {
+      await provider.detectNetwork()
+      logger.info(`Successfully connected to network: ${name}.`)
+      break
+    } catch (err) {
+      if (i < 9) {
+        logger.info(
+          `Unable to connect network: ${name}, will try ${
+            10 - i
+          } more time(s)...`
+        )
+        await sleep(1000)
+      } else {
+        throw new Error(
+          `Unable to connect to network: ${name}, check that your endpoint is correct.`
+        )
+      }
+    }
+  }
+}
+
+export const smartSendTransaction = async ({
+  contract,
+  functionName,
+  functionParams = [],
+  acceptableErrors = [],
+  logger,
+}: {
+  contract: Contract
+  functionName: string
+  functionParams?: any[]
+  acceptableErrors?: Array<{
+    errors: string[]
+    reason: string
+  }>
+  logger?: any
+}): Promise<void> => {
+  try {
+    await await contract[functionName](...functionParams).wait()
+  } catch (err) {
+    try {
+      await contract.callStatic[functionName](...functionParams)
+    } catch (err) {
+      for (const acceptableError of acceptableErrors) {
+        for (const error of acceptableError.errors) {
+          if (err.toString().includes(error)) {
+            if (logger) {
+              logger.info(acceptableError.reason)
+            }
+
+            return
+          }
+        }
+      }
+
+      throw err
+    }
   }
 }

--- a/src/utils/eth-utils.ts
+++ b/src/utils/eth-utils.ts
@@ -1,7 +1,8 @@
-import * as rlp from 'rlp'
-import { BigNumber, Contract, logger } from 'ethers'
+/* Imports: External */
+import { BigNumber, Contract } from 'ethers'
 import { Account, BN } from 'ethereumjs-util'
 
+/* Imports: Internal */
 import { sleep } from './common'
 import { toHexString, fromHexString } from './hex-utils'
 import { JsonRpcProvider } from '@ethersproject/providers'

--- a/src/utils/eth-utils.ts
+++ b/src/utils/eth-utils.ts
@@ -4,7 +4,7 @@ import { Account, BN } from 'ethereumjs-util'
 
 /* Imports: Internal */
 import { sleep } from './common'
-import { toHexString, fromHexString } from './hex-utils'
+import { toHexString, fromHexString, asciiToHex } from './hex-utils'
 import { JsonRpcProvider } from '@ethersproject/providers'
 
 export const encodeAccountState = (state: Partial<any>): Buffer => {
@@ -79,7 +79,10 @@ export const smartSendTransaction = async ({
     } catch (err) {
       for (const acceptableError of acceptableErrors) {
         for (const error of acceptableError.errors) {
-          if (err.toString().includes(error)) {
+          if (
+            err.toString().includes(error) ||
+            err.toString().includes(asciiToHex(error))
+          ) {
             if (logger) {
               logger.info(acceptableError.reason)
             }

--- a/src/utils/hex-utils.ts
+++ b/src/utils/hex-utils.ts
@@ -1,3 +1,4 @@
+/* Imports: External */
 import { BigNumber } from 'ethers'
 
 export const fromHexString = (buf: Buffer | string): Buffer => {

--- a/src/utils/hex-utils.ts
+++ b/src/utils/hex-utils.ts
@@ -69,3 +69,7 @@ export const toStrippedHexString = (buf: Buffer | string | number): string => {
     return '0x' + hex
   }
 }
+
+export const asciiToHex = (str: string): string => {
+  return Buffer.from(str, 'ascii').toString('hex')
+}

--- a/src/utils/logger.ts
+++ b/src/utils/logger.ts
@@ -1,3 +1,4 @@
+/* Imports: External */
 import colors from 'colors/safe'
 
 /**

--- a/src/utils/ovm-contracts.ts
+++ b/src/utils/ovm-contracts.ts
@@ -1,4 +1,4 @@
-import { Contract } from 'ethers'
+import { Contract, Signer } from 'ethers'
 import { JsonRpcProvider } from '@ethersproject/providers'
 import { getContractInterface } from '@eth-optimism/contracts/build/src/contract-defs'
 
@@ -43,4 +43,70 @@ export const loadProxyFromManager = async (
   }
 
   return loadContract(name, address, provider)
+}
+
+const loadAddressManager = async (
+  l1RpcProvider: JsonRpcProvider,
+  l2RpcProvider: JsonRpcProvider
+): Promise<Contract> => {
+  const addressManagerAddress = (await l2RpcProvider.send('rollup_getInfo', []))
+    .addresses.addressResolver
+
+  return loadContract(
+    'Lib_AddressManager',
+    addressManagerAddress,
+    l1RpcProvider
+  )
+}
+
+export interface OptimismContracts {
+  OVM_StateCommitmentChain: Contract
+  OVM_CanonicalTransactionChain: Contract
+  OVM_FraudVerifier: Contract
+  OVM_ExecutionManager: Contract
+}
+
+export const loadOptimismContracts = async (
+  l1RpcProvider: JsonRpcProvider,
+  l2RpcProvider: JsonRpcProvider,
+  signer: Signer
+): Promise<OptimismContracts> => {
+  const Lib_AddressManager = await loadAddressManager(
+    l1RpcProvider,
+    l2RpcProvider
+  )
+
+  const inputs = [
+    {
+      name: 'OVM_StateCommitmentChain',
+      interface: 'iOVM_StateCommitmentChain',
+    },
+    {
+      name: 'OVM_CanonicalTransactionChain',
+      interface: 'iOVM_CanonicalTransactionChain',
+    },
+    {
+      name: 'OVM_FraudVerifier',
+      interface: 'iOVM_FraudVerifier',
+    },
+    {
+      name: 'OVM_ExecutionManager',
+      interface: 'iOVM_ExecutionManager',
+    },
+  ]
+
+  const contracts = {}
+  for (const input of inputs) {
+    contracts[input.name] = (
+      await loadProxyFromManager(
+        input.interface,
+        input.name,
+        Lib_AddressManager,
+        l1RpcProvider
+      )
+    ).connect(signer)
+  }
+
+  // TODO: sorry
+  return contracts as OptimismContracts
 }

--- a/src/utils/ovm-contracts.ts
+++ b/src/utils/ovm-contracts.ts
@@ -1,7 +1,9 @@
+/* Imports: External */
 import { Contract, Signer } from 'ethers'
 import { JsonRpcProvider } from '@ethersproject/providers'
 import { getContractInterface } from '@eth-optimism/contracts/build/src/contract-defs'
 
+/* Imports: Internal */
 import { ZERO_ADDRESS } from './constants'
 
 export const loadContract = (

--- a/src/utils/ovm-utils.ts
+++ b/src/utils/ovm-utils.ts
@@ -1,5 +1,7 @@
+/* Imports: External */
 import { ethers } from 'ethers'
 
+/* Imports: Internal */
 import { OvmTransaction } from '../types'
 import { toUint256, toUint8, toHexString, fromHexString } from './hex-utils'
 

--- a/src/utils/providers/l1-provider-wrapper.ts
+++ b/src/utils/providers/l1-provider-wrapper.ts
@@ -1,7 +1,9 @@
+/* Imports: External */
 import { JsonRpcProvider } from '@ethersproject/providers'
 import { ethers, Event, Contract, BigNumber } from 'ethers'
 import { MerkleTree } from 'merkletreejs'
 
+/* Imports: Internal */
 import {
   StateRootBatchHeader,
   StateRootBatchProof,

--- a/src/utils/providers/l1-provider-wrapper.ts
+++ b/src/utils/providers/l1-provider-wrapper.ts
@@ -366,12 +366,6 @@ export class L1ProviderWrapper {
       return
     }
 
-    if (results.length > 2) {
-      throw new Error(
-        `Found more than one batch header for the same state root, this shouldn't happen.`
-      )
-    }
-
     return results[results.length - 1]
   }
 

--- a/src/utils/providers/l2-provider-wrapper.ts
+++ b/src/utils/providers/l2-provider-wrapper.ts
@@ -1,5 +1,7 @@
+/* Imports: External */
 import { JsonRpcProvider } from '@ethersproject/providers'
 
+/* Imports: Internal */
 import { StateDiffProof } from '../../types'
 import { toUnpaddedHexString } from '../hex-utils'
 

--- a/src/utils/trie-utils.ts
+++ b/src/utils/trie-utils.ts
@@ -1,4 +1,7 @@
+/* Imports: External */
 import { BaseTrie } from 'merkle-patricia-tree'
+
+/* Imports: Internal */
 import { fromHexString } from './hex-utils'
 
 export const makeTrieFromProofs = (proofs: string[][]): Promise<BaseTrie> => {


### PR DESCRIPTION
Tasks:

- [ ] Rename environment variables
- [ ] Have separate env files for the different services (possibly just use a better configuration pattern)
- [ ] Push all defaults into the service classes instead of the exec files
- [ ] Have the exec files just be run as typescript so we don't need to build every time
- [ ] Make message relayer use the utilities that the fraud prover already uses
- [ ] Add comments to message relayer
- [ ] Add comments to utilities