### PR TITLE
Improve message relayer efficiency, improve logs

### DIFF
--- a/src/exec/run.ts
+++ b/src/exec/run.ts
@@ -12,6 +12,7 @@ const ADDRESS_MANAGER_ADDRESS = env.ADDRESS_MANAGER_ADDRESS
 const L1_WALLET_KEY = env.L1_WALLET_KEY
 const RELAY_GAS_LIMIT = env.RELAY_GAS_LIMIT || '4000000'
 const POLLING_INTERVAL = env.POLLING_INTERVAL || '5000'
+const GET_LOGS_INTERVAL = env.GET_LOGS_INTERVAL || '2000'
 const L2_BLOCK_OFFSET = env.L2_BLOCK_OFFSET || '1'
 const L1_START_OFFSET = env.L1_BLOCK_OFFSET || '1'
 const FROM_L2_TRANSACTION_INDEX = env.FROM_L2_TRANSACTION_INDEX || '0'
@@ -67,6 +68,7 @@ const main = async () => {
     pollingInterval: parseInt(POLLING_INTERVAL, 10),
     l2BlockOffset: parseInt(L2_BLOCK_OFFSET, 10),
     l1StartOffset: parseInt(L1_START_OFFSET, 10),
+    getLogsInterval: parseInt(GET_LOGS_INTERVAL, 10),
     spreadsheetMode: !!SPREADSHEET_MODE,
     spreadsheet,
   })

--- a/src/services/message-relayer.service.ts
+++ b/src/services/message-relayer.service.ts
@@ -42,7 +42,11 @@ interface MessageRelayerOptions {
   // on L2 after the genesis but before the first state commitment is published.
   l2BlockOffset?: number
 
+  // L1 block to start querying events from. Recommended to set to the StateCommitmentChain deploy height
   l1StartOffset?: number
+
+  // Number of blocks within each getLogs query - max is 2000
+  getLogsInterval?: number
 
   // Append txs to a spreadsheet instead of submitting transactions
   spreadsheetMode?: boolean
@@ -57,6 +61,7 @@ export class MessageRelayerService extends BaseService<MessageRelayerOptions> {
     pollingInterval: 5000,
     l2BlockOffset: 1,
     l1StartOffset: 0,
+    getLogsInterval: 2000,
     spreadsheetMode: false,
   }
 
@@ -246,13 +251,13 @@ export class MessageRelayerService extends BaseService<MessageRelayerOptions> {
       this.state.lastQueriedL1Block = startingBlock
       this.logger.info(
         `Querying events from L1 block ${startingBlock} to ${
-          startingBlock + 2000
+          startingBlock + this.options.getLogsInterval
         }...`
       )
       const events: ethers.Event[] = await this.state.OVM_StateCommitmentChain.queryFilter(
         filter,
         startingBlock,
-        startingBlock + 2000
+        startingBlock + this.options.getLogsInterval
       )
       const event = events.find((event) => {
         return (
@@ -284,7 +289,7 @@ export class MessageRelayerService extends BaseService<MessageRelayerOptions> {
           stateRoots: stateRoots,
         }
       }
-      startingBlock += 1000
+      startingBlock += this.options.getLogsInterval
     }
     return
   }

--- a/src/services/message-relayer.service.ts
+++ b/src/services/message-relayer.service.ts
@@ -81,7 +81,7 @@ export class MessageRelayerService extends BaseService<MessageRelayerOptions> {
 
   protected async _init(): Promise<void> {
     this.logger.info(
-      `Initializing message relater with options: ${this.options}`
+      `Initializing message relayer with options: ${this.options}`
     )
     // Need to improve this, sorry.
     this.state = {} as any

--- a/src/services/message-relayer.service.ts
+++ b/src/services/message-relayer.service.ts
@@ -75,7 +75,9 @@ export class MessageRelayerService extends BaseService<MessageRelayerOptions> {
   }
 
   protected async _init(): Promise<void> {
-    this.logger.info(`initializing message relater with options: ${this.options}`)
+    this.logger.info(
+      `Initializing message relater with options: ${this.options}`
+    )
     // Need to improve this, sorry.
     this.state = {} as any
 
@@ -242,7 +244,11 @@ export class MessageRelayerService extends BaseService<MessageRelayerOptions> {
       startingBlock < (await this.options.l1RpcProvider.getBlockNumber())
     ) {
       this.state.lastQueriedL1Block = startingBlock
-      this.logger.info(`Querying events from L1 block ${startingBlock} to ${startingBlock+2000}...`)
+      this.logger.info(
+        `Querying events from L1 block ${startingBlock} to ${
+          startingBlock + 2000
+        }...`
+      )
       const events: ethers.Event[] = await this.state.OVM_StateCommitmentChain.queryFilter(
         filter,
         startingBlock,
@@ -291,7 +297,9 @@ export class MessageRelayerService extends BaseService<MessageRelayerOptions> {
       this.logger.info(`No state batch header found.`)
       return false
     } else {
-      this.logger.info(`Got state batch header: ${JSON.stringify(header, null, 2)}`)
+      this.logger.info(
+        `Got state batch header: ${JSON.stringify(header, null, 2)}`
+      )
     }
 
     return !(await this.state.OVM_StateCommitmentChain.insideFraudProofWindow(


### PR DESCRIPTION
Drastically improves the efficiency of the message relayer - Previously, would query events from l1BlockOffset to latest blockNumber after every batch was found. This change would query events from l1BlockOffset until finding the right state batch. Then the relayer would store the last queried L1 block and look for the next state batch starting at the last queried L1 block.