### PR TITLE
logging: log the eoa used by the service at start

### DIFF
--- a/src/services/fraud-prover.service.ts
+++ b/src/services/fraud-prover.service.ts
@@ -73,6 +73,9 @@ export class FraudProverService extends BaseService<FraudProverOptions> {
     // Need to improve this, sorry.
     this.state = {} as any
 
+    const address = await this.options.l1Wallet.getAddress()
+    this.logger.info(`Using L1 EOA: ${address}`)
+
     this.logger.info(`Trying to connect to the L1 network...`)
     for (let i = 0; i < 10; i++) {
       try {

--- a/src/services/message-relayer.service.ts
+++ b/src/services/message-relayer.service.ts
@@ -87,6 +87,9 @@ export class MessageRelayerService extends BaseService<MessageRelayerOptions> {
     // Need to improve this, sorry.
     this.state = {} as any
 
+    const address = await this.options.l1Wallet.getAddress()
+    this.logger.info(`Using L1 EOA: ${address}`)
+
     this.state.Lib_AddressManager = loadContract(
       'Lib_AddressManager',
       this.options.addressManagerAddress,


### PR DESCRIPTION
Adds a logline to print off the address used by the service at startup. This is helpful for debugging permissioned contracts. I thought about adding it to the base service, but I think that would have required a bit of a refactor.