### PR TITLE
config: allow mnemonic

### DIFF
--- a/src/exec/run-fraud-prover.ts
+++ b/src/exec/run-fraud-prover.ts
@@ -9,6 +9,8 @@ const env = process.env
 const L2_NODE_WEB3_URL = env.L2_NODE_WEB3_URL
 const L1_NODE_WEB3_URL = env.L1_NODE_WEB3_URL
 const L1_WALLET_KEY = env.L1_WALLET_KEY
+const MNEMONIC = env.MNEMONIC
+const HD_PATH = env.HD_PATH
 const RELAY_GAS_LIMIT = env.RELAY_GAS_LIMIT || '4000000'
 const RUN_GAS_LIMIT = env.RUN_GAS_LIMIT || '95000000'
 const POLLING_INTERVAL = env.POLLING_INTERVAL || '5000'
@@ -21,7 +23,15 @@ const main = async () => {
   const l2Provider = new JsonRpcProvider(L2_NODE_WEB3_URL)
   const l1Provider = new JsonRpcProvider(L1_NODE_WEB3_URL)
 
-  const wallet = new Wallet(L1_WALLET_KEY, l1Provider)
+  let wallet: Wallet
+  if (L1_WALLET_KEY) {
+    wallet = new Wallet(L1_WALLET_KEY, l1Provider)
+  } else if (MNEMONIC) {
+    wallet = Wallet.fromMnemonic(MNEMONIC, HD_PATH)
+    wallet = wallet.connect(l1Provider)
+  } else {
+    throw new Error('Must pass one of L1_PRIVATE_KEY or MNEMONIC')
+  }
 
   const service = new FraudProverService({
     l1RpcProvider: l1Provider,

--- a/src/exec/run.ts
+++ b/src/exec/run.ts
@@ -10,6 +10,8 @@ const L2_NODE_WEB3_URL = env.L2_NODE_WEB3_URL
 const L1_NODE_WEB3_URL = env.L1_NODE_WEB3_URL
 const ADDRESS_MANAGER_ADDRESS = env.ADDRESS_MANAGER_ADDRESS
 const L1_WALLET_KEY = env.L1_WALLET_KEY
+const MNEMONIC = env.MNEMONIC
+const HD_PATH = env.HD_PATH
 const RELAY_GAS_LIMIT = env.RELAY_GAS_LIMIT || '4000000'
 const POLLING_INTERVAL = env.POLLING_INTERVAL || '5000'
 const GET_LOGS_INTERVAL = env.GET_LOGS_INTERVAL || '2000'
@@ -40,7 +42,15 @@ const main = async () => {
   const l2Provider = new JsonRpcProvider(L2_NODE_WEB3_URL)
   const l1Provider = new JsonRpcProvider(L1_NODE_WEB3_URL)
 
-  const wallet = new Wallet(L1_WALLET_KEY, l1Provider)
+  let wallet: Wallet
+  if (L1_WALLET_KEY) {
+    wallet = new Wallet(L1_WALLET_KEY, l1Provider)
+  } else if (MNEMONIC) {
+    wallet = Wallet.fromMnemonic(MNEMONIC, HD_PATH)
+    wallet = wallet.connect(l1Provider)
+  } else {
+    throw new Error('Must pass one of L1_PRIVATE_KEY or MNEMONIC')
+  }
 
   let spreadsheet = null
   if (SPREADSHEET_MODE) {


### PR DESCRIPTION
Allows for mnemonic based configuration for both the fraud-prover and message relayer